### PR TITLE
Mutability error in renderString method

### DIFF
--- a/lib/compstache.js
+++ b/lib/compstache.js
@@ -18,7 +18,7 @@ function Compstache(cache) {
 		if (!data) {
 			data = {};
 		}
-		data = _.defaults(special, transclusions, data);
+		data = _.defaults({}, special, transclusions, data);
 		return Mustache.render(template, data, cache);
 	}
 

--- a/test/compstache.spec.js
+++ b/test/compstache.spec.js
@@ -103,6 +103,17 @@ describe('Compstache', function () {
 				should(render('foo', data)).eql('It is basic here');
 			});
 
+			it('should render from cache and interpolate new values', function () {
+				var dataA = {
+					condition: 'moderate'
+				};
+				var dataB = {
+					condition: 'advanced'
+				};
+				render('foo', dataA);
+				should(render('foo', dataB)).eql('It is advanced here');
+			});
+
 		});
 
 	});


### PR DESCRIPTION
There's an issue in the current implementation, which would cause the `renderString()` method to always interpolate the same data due to `var special` object defined in `Compstache()` scope getting overwritten.

Fix included, along with test to replicate this issue.

Note, the `_.defaults()` method will only fill `undefined` properties. Documentation available at http://underscorejs.org/#defaults.
